### PR TITLE
bump enketo express to 7.5.1 DEV-4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM enketo/enketo-express:7.3.1
+FROM enketo/enketo-express:7.5.1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates && \
@@ -29,8 +29,8 @@ RUN git apply /tmp/disclaimer-css.patch
 # Please note that widgets must also be listed in the run-time config.json to
 # be enabled.
 RUN yarn workspace enketo-express add \
-    https://github.com/kobotoolbox/enketo-image-customization-widget#cd36c2c050e521b9c8a9f7c2f00f7c7c0bc3ec67 \
-    https://github.com/kobotoolbox/enketo-literacy-test-widget#b89f5cf8e03df5a33802d19a03807216c1c1d328 \
+    https://github.com/kobotoolbox/enketo-image-customization-widget#c98179be9359013c7d918031a1031524577a634d \
+    https://github.com/kobotoolbox/enketo-literacy-test-widget#28b91c54ace66631f627203bb5e3c2a7c4599981 \
     && yarn workspace enketo-express run build \
     && yarn cache clean \
     && rm packages/enketo-express/config/config.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,11 @@ RUN git apply /tmp/disclaimer-css.patch
 
 # Please note that widgets must also be listed in the run-time config.json to
 # be enabled.
+# ATTENTION: It seems bonkers to install `proxy-agent` here, but without it,
+# the `add` operation fails with
+#     Invariant Violation: expected workspace package to exist for "proxy-agent"
 RUN yarn workspace enketo-express add \
+    'proxy-agent@^6.5.0' \
     https://github.com/kobotoolbox/enketo-image-customization-widget#c98179be9359013c7d918031a1031524577a634d \
     https://github.com/kobotoolbox/enketo-literacy-test-widget#28b91c54ace66631f627203bb5e3c2a7c4599981 \
     && yarn workspace enketo-express run build \


### PR DESCRIPTION
This PR bumps up enketo express version to 7.5.1 aiming to solve a bug existent in the current used version of enketo-express.

Bug reference:
- [Customer support thread](https://chat.kobotoolbox.org/#narrow/stream/6-Kobo-Support/topic/ACF.20Enketo.20iOS.20signature.20missing)
- [Zulip Thread](https://chat.kobotoolbox.org/#narrow/stream/13-Enketo/topic/Data.20loss.20with.20Enketo.20signature.20pad.20widget)

The following PRs are pairs with this one to bump widgets versions due to node version requirements from enketo-express 7.5.1:

- image customization: https://github.com/kobotoolbox/enketo-image-customization-widget/pull/8
- literacy test: https://github.com/kobotoolbox/enketo-literacy-test-widget/pull/43


This pull request includes updates to the `Dockerfile` to enhance the application by upgrading dependencies and widgets.